### PR TITLE
Get request fixer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,3 @@ before_script:
 
 script:
     - phpunit
-
-matrix:
-  allow_failures:
-    - php: 7.0

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ You can run these commands to easily access ``symfony-upgrade-fixer`` from anywh
 your system:
 
 ```bash
-$ sudo wget https://github.com/umpirsky/Symfony-Upgrade-Fixer/releases/download/v0.1.1/symfony-upgrade-fixer.phar -O /usr/local/bin/symfony-upgrade-fixer
+$ sudo wget https://github.com/umpirsky/Symfony-Upgrade-Fixer/releases/download/v0.1.2/symfony-upgrade-fixer.phar -O /usr/local/bin/symfony-upgrade-fixer
 $ sudo chmod a+x /usr/local/bin/symfony-upgrade-fixer
 ```
 Then, just run ``symfony-upgrade-fixer``.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ $ symfony-upgrade-fixer fix /path/to/code --dry-run
 | form_option_names | Options precision and virtual was renamed to scale and inherit_data. |
 | form_parent_type | Returning type instances from FormTypeInterface::getParent() is deprecated, return the fully-qualified class name of the parent type class instead. |
 | form_type_names | Instead of referencing types by name, you should reference them by their fully-qualified class name (FQCN) instead. |
+| get_request | The getRequest method of the base controller class was removed, request object is injected in the action method instead. |
 | inherit_data_aware_iterator | The class VirtualFormAwareIterator was renamed to InheritDataAwareIterator. |
 | progress_bar | ProgressHelper has been removed in favor of ProgressBar. |
 | property_access | Renamed PropertyAccess::getPropertyAccessor to PropertyAccess::createPropertyAccessor. |

--- a/src/Symfony/Upgrade/Fixer.php
+++ b/src/Symfony/Upgrade/Fixer.php
@@ -12,7 +12,7 @@ use Symfony\Upgrade\Fixer\Iterator\FixerIterator;
 
 class Fixer
 {
-    const VERSION = '0.1.1';
+    const VERSION = '0.1.2';
 
     private $fixers = [];
     private $finder;

--- a/src/Symfony/Upgrade/Fixer/AbstractFixer.php
+++ b/src/Symfony/Upgrade/Fixer/AbstractFixer.php
@@ -77,4 +77,18 @@ abstract class AbstractFixer extends BaseAbstractFixer
             )
         );
     }
+
+    protected function extendsClass(Tokens $tokens, array $fqcn)
+    {
+        if (!$this->hasUseStatements($tokens, $fqcn)) {
+            return false;
+        }
+
+        return null !== $tokens->findSequence([
+            [T_CLASS],
+            [T_STRING],
+            [T_EXTENDS],
+            [T_STRING, array_pop($fqcn)],
+        ]);
+    }
 }

--- a/src/Symfony/Upgrade/Fixer/FormConfigureOptionsFixer.php
+++ b/src/Symfony/Upgrade/Fixer/FormConfigureOptionsFixer.php
@@ -2,7 +2,6 @@
 
 namespace Symfony\Upgrade\Fixer;
 
-use Symfony\CS\Tokenizer\Token;
 use Symfony\CS\Tokenizer\Tokens;
 
 class FormConfigureOptionsFixer extends FormTypeFixer

--- a/src/Symfony/Upgrade/Fixer/FormTypeFixer.php
+++ b/src/Symfony/Upgrade/Fixer/FormTypeFixer.php
@@ -41,16 +41,7 @@ abstract class FormTypeFixer extends AbstractFixer
 
     protected function isFormType(Tokens $tokens)
     {
-        if (!$this->hasUseStatements($tokens, ['Symfony', 'Component', 'Form', 'AbstractType'])) {
-            return false;
-        }
-
-        return null !== $tokens->findSequence([
-            [T_CLASS],
-            [T_STRING],
-            [T_EXTENDS],
-            [T_STRING, 'AbstractType'],
-        ]);
+        return $this->extendsClass($tokens, ['Symfony', 'Component', 'Form', 'AbstractType']);
     }
 
     protected function addTypeUse(Tokens $tokens, $name)

--- a/src/Symfony/Upgrade/Fixer/FormTypeFixer.php
+++ b/src/Symfony/Upgrade/Fixer/FormTypeFixer.php
@@ -2,7 +2,6 @@
 
 namespace Symfony\Upgrade\Fixer;
 
-use Symfony\CS\Tokenizer\Token;
 use Symfony\CS\Tokenizer\Tokens;
 
 abstract class FormTypeFixer extends AbstractFixer

--- a/src/Symfony/Upgrade/Fixer/GetRequestFixer.php
+++ b/src/Symfony/Upgrade/Fixer/GetRequestFixer.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Symfony\Upgrade\Fixer;
+
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+class GetRequestFixer extends AbstractFixer
+{
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        if ($this->isController($tokens)) {
+            $this->fixGetRequests($tokens);
+        }
+
+        return $tokens->generateCode();
+    }
+
+    public function getDescription()
+    {
+        return 'The getRequest method of the base controller class was removed, request object is injected in the action method instead.';
+    }
+
+    private function isController(Tokens $tokens)
+    {
+        return $this->extendsClass($tokens, ['Symfony', 'Bundle', 'FrameworkBundle', 'Controller', 'Controller']);
+    }
+
+    private function fixGetRequests(Tokens $tokens)
+    {
+        $todo = [];
+
+        foreach ($this->getClassyElementsIndexed($tokens) as $i => $element) {
+            if ('method' === $element['type']) {
+                if ($this->fixActionParameters($tokens, $element['index'])) {
+                    $todo[] = $i;
+                }
+            }
+        }
+
+        foreach ($this->getClassyElementsIndexed($tokens) as $i => $element) {
+            if (in_array($i, $todo)) {
+                $this->fixActionBody($tokens, $element['index']);
+            }
+        }
+    }
+
+    private function getClassyElementsIndexed(Tokens $tokens)
+    {
+        $elements = [];
+
+        foreach ($tokens->getClassyElements() as $index => $element) {
+            $element['index'] = $index;
+            $elements[] = $element;
+        }
+
+        return $elements;
+    }
+
+    private function fixActionParameters(Tokens $tokens, $index)
+    {
+        if (!$this->isAction($tokens, $index)) {
+            return;
+        }
+
+        $parenthesisIndexes = $this->getActionParenthesisIndexes($tokens, $index);
+        if ($this->hasRequestParameterSequence($tokens, $parenthesisIndexes[0], $parenthesisIndexes[1])) {
+            return;
+        }
+
+        $curlyBraceIndexes = $this->getActionCurlyBraceIndexes($tokens, $index);
+        if (!$this->hasGetRequestSequence($tokens, $curlyBraceIndexes[0], $curlyBraceIndexes[1])) {
+            return;
+        }
+
+        if (null === $requestVariableName = $this->getRequestVariableName($tokens, $curlyBraceIndexes[0], $curlyBraceIndexes[1])) {
+            return;
+        }
+
+        $insertAt = $tokens->getNextMeaningfulToken($parenthesisIndexes[0]);
+
+        $tokens->insertAt(
+            $insertAt,
+            array_merge(
+                [
+                    new Token([T_STRING, 'Request']),
+                    new Token([T_WHITESPACE, ' ']),
+                    new Token([T_VARIABLE, $requestVariableName]),
+                ],
+                $parenthesisIndexes[1] - $parenthesisIndexes[0] > 1 ? [new Token(','), new Token([T_WHITESPACE, ' '])] : []
+            )
+        );
+
+        $this->addUseStatement(
+            $tokens,
+            ['Symfony', 'Component', 'HttpFoundation', 'Request']
+        );
+
+        return true;
+    }
+
+    private function fixActionBody(Tokens $tokens, $index)
+    {
+        $curlyBraceIndexes = $this->getActionCurlyBraceIndexes($tokens, $index);
+        if (!$this->hasGetRequestSequence($tokens, $curlyBraceIndexes[0], $curlyBraceIndexes[1])) {
+            return;
+        }
+
+        $clearFrom = $tmp = $this->getRequestVariableTokenIndex($tokens, $curlyBraceIndexes[0], $curlyBraceIndexes[1]);
+        $keys = array_keys($this->getGetRequestSequence($tokens, $curlyBraceIndexes[0], $curlyBraceIndexes[1]));
+        $clearTo = array_pop($keys);
+        $clearTo = $tokens->getNextMeaningfulToken($clearTo);
+        if (!$tokens[$clearTo]->equals(';')) {
+            return;
+        }
+
+        $tokens->clearRange($clearFrom, $clearTo);
+        $tokens->removeTrailingWhitespace($clearTo);
+    }
+
+    private function isAction(Tokens $tokens, $index)
+    {
+        $actionNameToken = $tokens[$tokens->getNextMeaningfulToken($index)];
+
+        if (!$actionNameToken->isGivenKind(T_STRING)) {
+            return false;
+        }
+        if (substr($actionNameToken->getContent(), -6) !== 'Action') {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function getActionParenthesisIndexes(Tokens $tokens, $index)
+    {
+        $openIndex = $tokens->getNextMeaningfulToken($tokens->getNextMeaningfulToken($index));
+        $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_PARENTHESIS_BRACE, $openIndex);
+
+        return [$openIndex, $closeIndex];
+    }
+
+    private function getActionCurlyBraceIndexes(Tokens $tokens, $index)
+    {
+        $openIndex = $tokens->getNextMeaningfulToken(
+            $this->getActionParenthesisIndexes($tokens, $index)[1]
+        );
+        $closeIndex = $tokens->findBlockEnd(Tokens::BLOCK_TYPE_CURLY_BRACE, $openIndex);
+
+        return [$openIndex, $closeIndex];
+    }
+
+    private function hasRequestParameterSequence(Tokens $tokens, $start, $end)
+    {
+        return null !== $tokens->findSequence([
+            [T_STRING, 'Request'],
+            [T_VARIABLE],
+        ], $start, $end);
+    }
+
+    private function hasGetRequestSequence(Tokens $tokens, $start, $end)
+    {
+        return null !== $this->getGetRequestSequence($tokens, $start, $end);
+    }
+
+    private function getGetRequestSequence(Tokens $tokens, $start, $end)
+    {
+        return $tokens->findSequence([
+            [T_VARIABLE, '$this'],
+            [T_OBJECT_OPERATOR],
+            [T_STRING, 'getRequest'],
+            '(',
+            ')',
+        ], $start, $end);
+    }
+
+    private function getRequestVariableName(Tokens $tokens, $start, $end)
+    {
+        $requestVariableTokenIndex = $this->getRequestVariableTokenIndex($tokens, $start, $end);
+        $requestVariableToken = $tokens[$requestVariableTokenIndex];
+        if (!$requestVariableToken->isGivenKind(T_VARIABLE)) {
+            return;
+        }
+
+        return $requestVariableToken->getContent();
+    }
+
+    private function getRequestSequenceStartTokenIndex(Tokens $tokens, $start, $end)
+    {
+        $getRequestSequence = $this->getGetRequestSequence($tokens, $start, $end);
+
+        return array_keys($getRequestSequence)[0];
+    }
+
+    private function getRequestVariableTokenIndex(Tokens $tokens, $start, $end)
+    {
+        $getRequestSequenceStartIndex = $this->getRequestSequenceStartTokenIndex($tokens, $start, $end);
+
+        $assignTokenIndex = $tokens->getPrevMeaningfulToken($getRequestSequenceStartIndex);
+        if ('=' !== $tokens[$assignTokenIndex]->getContent()) {
+            return;
+        }
+
+        return $tokens->getPrevMeaningfulToken($assignTokenIndex);
+    }
+}

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case1-input.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case1-input.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Umpirsky\UpgradeBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class DemoController extends Controller
+{
+    public function showAction($slug)
+    {
+        $request = $this->getRequest();
+        // ...
+    }
+}

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case1-output.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case1-output.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Umpirsky\UpgradeBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class DemoController extends Controller
+{
+    public function showAction(Request $request, $slug)
+    {
+        // ...
+    }
+}

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case2-input.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case2-input.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Umpirsky\UpgradeBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class DemoController extends Controller
+{
+    public function showAction()
+    {
+        $request = $this->getRequest();
+        // ...
+    }
+
+    private function helperMethod()
+    {
+        // ...
+    }
+}

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case2-output.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case2-output.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Umpirsky\UpgradeBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class DemoController extends Controller
+{
+    public function showAction(Request $request)
+    {
+        // ...
+    }
+
+    private function helperMethod()
+    {
+        // ...
+    }
+}

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case3-input.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case3-input.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Umpirsky\UpgradeBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class DemoController extends Controller
+{
+    public function showAction()
+    {
+        $username = $this->getRequest()->request->get('username');
+        // ...
+    }
+}

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case3-output.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/get-request/case3-output.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Umpirsky\UpgradeBundle\Controller;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+
+class DemoController extends Controller
+{
+    public function showAction(Request $request)
+    {
+        $username = $request->request->get('username');
+        // ...
+    }
+}

--- a/tests/Symfony/Upgrade/Test/Fixer/GetRequestFixerTest.php
+++ b/tests/Symfony/Upgrade/Test/Fixer/GetRequestFixerTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Symfony\Upgrade\Test\Fixer;
+
+class GetRequestFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideExamples
+     */
+    public function testFix($expected, $input, $file)
+    {
+        $this->makeTest($expected, $input, $file);
+    }
+
+    public function provideExamples()
+    {
+        return [
+            $this->prepareTestCase('case1-output.php', 'case1-input.php'),
+            $this->prepareTestCase('case2-output.php', 'case2-input.php'),
+        ];
+    }
+}

--- a/tests/Symfony/Upgrade/Test/Fixer/GetRequestFixerTest.php
+++ b/tests/Symfony/Upgrade/Test/Fixer/GetRequestFixerTest.php
@@ -17,6 +17,7 @@ class GetRequestFixerTest extends AbstractFixerTestBase
         return [
             $this->prepareTestCase('case1-output.php', 'case1-input.php'),
             $this->prepareTestCase('case2-output.php', 'case2-input.php'),
+            $this->prepareTestCase('case3-output.php', 'case3-input.php'),
         ];
     }
 }


### PR DESCRIPTION
The `getRequest` method of the base `Controller` class has been deprecated since Symfony 2.4 and must be therefore removed in 3.0. The only reliable way to get the `Request` object is to inject it in the action method.

Before:
```php
namespace Acme\FooBundle\Controller;

class DemoController
{
   public function showAction()
   {
       $request = $this->getRequest();
       // ...
   }
}
```
After:
```php
namespace Acme\FooBundle\Controller;

use Symfony\Component\HttpFoundation\Request;

class DemoController
{
   public function showAction(Request $request)
   {
       // ...
   }
}
```

Tested against [Oro Platform](https://github.com/umpirsky/platform/commit/2636e974fb31cb974e42dca192e3b8cd43abc714) and [Akeneo PIM](https://github.com/umpirsky/pim-community-dev/commit/8ea0ebf81497eb928703ae6d0bf24d98234ea8a1).