### PR TITLE
Add fixer for form type getName method.

### DIFF
--- a/src/Symfony/Upgrade/Fixer/FormGetnameToGetblockprefixFixer.php
+++ b/src/Symfony/Upgrade/Fixer/FormGetnameToGetblockprefixFixer.php
@@ -7,14 +7,8 @@ use Symfony\CS\Tokenizer\Tokens;
 
 class FormGetnameToGetblockprefixFixer extends FormTypeFixer
 {
-
     /**
-     * Fixes a file.
-     *
-     * @param \SplFileInfo $file A \SplFileInfo instance
-     * @param string       $content The file content
-     *
-     * @return string The fixed file content
+     * @inheritdoc
      */
     public function fix(\SplFileInfo $file, $content)
     {
@@ -41,24 +35,16 @@ class FormGetnameToGetblockprefixFixer extends FormTypeFixer
     private function fixGetNameMethod(Tokens $tokens)
     {
         $matchedTokens = $this->matchGetNameMethod($tokens);
-        if (null === $matchedTokens) {
-            return;
-        }
-
         $matchedIndexes = array_keys($matchedTokens);
         $matchedIndex = $matchedIndexes[count($matchedIndexes) - 3];
         $matchedTokens[$matchedIndex]->setContent('getBlockPrefix');
     }
 
     /**
-     * Returns the description of the fixer.
-     *
-     * A short one-line description of what the fixer does.
-     *
-     * @return string The description of the fixer
+     * @inheritdoc
      */
     public function getDescription()
     {
-        return 'The method FormTypeInterface::getName() was deprecated and will be removed in Symfony 3.0. You should now implement FormTypeInterface::getBlockPrefix() instead.';
+        return 'The method FormTypeInterface::getName() was deprecated, you should now implement FormTypeInterface::getBlockPrefix() instead.';
     }
 }

--- a/src/Symfony/Upgrade/Fixer/FormGetnameToGetblockprefixFixer.php
+++ b/src/Symfony/Upgrade/Fixer/FormGetnameToGetblockprefixFixer.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Symfony\Upgrade\Fixer;
+
+use Symfony\CS\Tokenizer\Token;
+use Symfony\CS\Tokenizer\Tokens;
+
+class FormGetnameToGetblockprefixFixer extends FormTypeFixer
+{
+
+    /**
+     * Fixes a file.
+     *
+     * @param \SplFileInfo $file A \SplFileInfo instance
+     * @param string       $content The file content
+     *
+     * @return string The fixed file content
+     */
+    public function fix(\SplFileInfo $file, $content)
+    {
+        $tokens = Tokens::fromCode($content);
+
+        if ($this->isFormType($tokens) && null !== $this->matchGetNameMethod($tokens)) {
+            $this->fixGetNameMethod($tokens);
+        }
+
+        return $tokens->generateCode();
+    }
+
+    private function matchGetNameMethod(Tokens $tokens)
+    {
+        return $tokens->findSequence([
+            [T_PUBLIC, 'public'],
+            [T_FUNCTION],
+            [T_STRING, 'getName'],
+            '(',
+            ')'
+        ]);
+    }
+
+    private function fixGetNameMethod(Tokens $tokens)
+    {
+        $matchedTokens = $this->matchGetNameMethod($tokens);
+        if (null === $matchedTokens) {
+            return;
+        }
+
+        $matchedIndexes = array_keys($matchedTokens);
+        $matchedIndex = $matchedIndexes[count($matchedIndexes) - 3];
+        $matchedTokens[$matchedIndex]->setContent('getBlockPrefix');
+    }
+
+    /**
+     * Returns the description of the fixer.
+     *
+     * A short one-line description of what the fixer does.
+     *
+     * @return string The description of the fixer
+     */
+    public function getDescription()
+    {
+        return 'The method FormTypeInterface::getName() was deprecated and will be removed in Symfony 3.0. You should now implement FormTypeInterface::getBlockPrefix() instead.';
+    }
+}

--- a/src/Symfony/Upgrade/Fixer/FormGetnameToGetblockprefixFixer.php
+++ b/src/Symfony/Upgrade/Fixer/FormGetnameToGetblockprefixFixer.php
@@ -8,13 +8,13 @@ use Symfony\CS\Tokenizer\Tokens;
 class FormGetnameToGetblockprefixFixer extends FormTypeFixer
 {
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function fix(\SplFileInfo $file, $content)
     {
         $tokens = Tokens::fromCode($content);
 
-        if ($this->isFormType($tokens) && null !== $this->matchGetNameMethod($tokens)) {
+        if ($this->isFormType($tokens)) {
             $this->fixGetNameMethod($tokens);
         }
 
@@ -35,13 +35,17 @@ class FormGetnameToGetblockprefixFixer extends FormTypeFixer
     private function fixGetNameMethod(Tokens $tokens)
     {
         $matchedTokens = $this->matchGetNameMethod($tokens);
+        if (null === $matchedTokens) {
+            return;
+        }
+
         $matchedIndexes = array_keys($matchedTokens);
         $matchedIndex = $matchedIndexes[count($matchedIndexes) - 3];
         $matchedTokens[$matchedIndex]->setContent('getBlockPrefix');
     }
 
     /**
-     * @inheritdoc
+     * {@inheritdoc}
      */
     public function getDescription()
     {

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/form-getname-to-getblockprefix/case1-input.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/form-getname-to-getblockprefix/case1-input.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Umpirsky\UpgradeBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class RegistrationFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+    }
+
+    public function getName()
+    {
+        return 'test_name';
+    }
+}

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/form-getname-to-getblockprefix/case1-output.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/form-getname-to-getblockprefix/case1-output.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Umpirsky\UpgradeBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class RegistrationFormType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+    }
+
+    public function getBlockPrefix()
+    {
+        return 'test_name';
+    }
+}

--- a/tests/Symfony/Upgrade/Test/Fixer/FormGetnameToGetblockprefixFixerTest.php
+++ b/tests/Symfony/Upgrade/Test/Fixer/FormGetnameToGetblockprefixFixerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Symfony\Upgrade\Test\Fixer;
+
+class FormGetnameToGetblockprefixFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideExamples
+     */
+    public function testFix($expected, $input, $file)
+    {
+        $this->makeTest($expected, $input, $file);
+    }
+
+    public function provideExamples()
+    {
+        return [
+            $this->prepareTestCase('case1-output.php', 'case1-input.php'),
+        ];
+    }
+}


### PR DESCRIPTION
From https://github.com/symfony/symfony/blob/2.8/UPGRADE-2.8.md

   As a further consequence, the method `FormTypeInterface::getName()` was
   deprecated and will be removed in Symfony 3.0. You should remove this method
   from your form types.

   If you want to customize the block prefix of a type in Twig, you should now
   implement `FormTypeInterface::getBlockPrefix()` instead:

   Before:

   ```php
   class UserProfileType extends AbstractType
   {
       public function getName()
       {
           return 'profile';
       }
   }
   ```

   After:

   ```php
   class UserProfileType extends AbstractType
   {
       public function getBlockPrefix()
       {
           return 'profile';
       }
   }
   ```