### PR TITLE
[WIP] Yaml fixer reloaded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": ">=5.4",
-        "fabpot/php-cs-fixer": "^1.10"
+        "fabpot/php-cs-fixer": "^1.10",
+        "symfony/yaml": "~2.7"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "bbd15dded2d63806c1e25250eca9dcfe",
-    "content-hash": "6f77cda9dbca29e46d0849dfa41ec7e9",
+    "hash": "697049394b34bb0eaa47d7ed600a1734",
+    "content-hash": "2746f180878673049ef7ff5ae5c0a3be",
     "packages": [
         {
             "name": "fabpot/php-cs-fixer",
@@ -63,28 +63,28 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "1.3.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3"
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/863df9687835c62aa423a22412d26fa2ebde3fd3",
-                "reference": "863df9687835c62aa423a22412d26fa2ebde3fd3",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/13edfd8706462032c2f52b4b862974dd46b71c9e",
+                "reference": "13edfd8706462032c2f52b4b862974dd46b71c9e",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "~4.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -107,33 +107,34 @@
                 }
             ],
             "description": "Diff implementation",
-            "homepage": "http://www.github.com/sebastianbergmann/diff",
+            "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
                 "diff"
             ],
-            "time": "2015-02-22 15:13:53"
+            "time": "2015-12-08 07:14:41"
         },
         {
             "name": "symfony/console",
-            "version": "v2.7.6",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "5efd632294c8320ea52492db22292ff853a43766"
+                "reference": "9a5aef5fc0d4eff86853d44202b02be8d5a20154"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/5efd632294c8320ea52492db22292ff853a43766",
-                "reference": "5efd632294c8320ea52492db22292ff853a43766",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9a5aef5fc0d4eff86853d44202b02be8d5a20154",
+                "reference": "9a5aef5fc0d4eff86853d44202b02be8d5a20154",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.9"
+                "php": ">=5.3.9",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/event-dispatcher": "~2.1",
-                "symfony/process": "~2.1"
+                "symfony/event-dispatcher": "~2.1|~3.0.0",
+                "symfony/process": "~2.1|~3.0.0"
             },
             "suggest": {
                 "psr/log": "For using the console logger",
@@ -143,13 +144,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Console\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -167,20 +171,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-20 14:38:46"
+            "time": "2016-03-17 09:19:04"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.7.6",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "87a5db5ea887763fa3a31a5471b512ff1596d9b8"
+                "reference": "47d2d8cade9b1c3987573d2943bb9352536cdb87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/87a5db5ea887763fa3a31a5471b512ff1596d9b8",
-                "reference": "87a5db5ea887763fa3a31a5471b512ff1596d9b8",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/47d2d8cade9b1c3987573d2943bb9352536cdb87",
+                "reference": "47d2d8cade9b1c3987573d2943bb9352536cdb87",
                 "shasum": ""
             },
             "require": {
@@ -188,10 +192,10 @@
             },
             "require-dev": {
                 "psr/log": "~1.0",
-                "symfony/config": "~2.0,>=2.0.5",
-                "symfony/dependency-injection": "~2.6",
-                "symfony/expression-language": "~2.6",
-                "symfony/stopwatch": "~2.3"
+                "symfony/config": "~2.0,>=2.0.5|~3.0.0",
+                "symfony/dependency-injection": "~2.6|~3.0.0",
+                "symfony/expression-language": "~2.6|~3.0.0",
+                "symfony/stopwatch": "~2.3|~3.0.0"
             },
             "suggest": {
                 "symfony/dependency-injection": "",
@@ -200,13 +204,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\EventDispatcher\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -224,20 +231,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-11 09:39:48"
+            "time": "2016-03-07 14:04:32"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v2.7.6",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "56fd6df73be859323ff97418d97edc1d756df6df"
+                "reference": "f08ffdf229252cd2745558cb2112df43903bcae4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/56fd6df73be859323ff97418d97edc1d756df6df",
-                "reference": "56fd6df73be859323ff97418d97edc1d756df6df",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/f08ffdf229252cd2745558cb2112df43903bcae4",
+                "reference": "f08ffdf229252cd2745558cb2112df43903bcae4",
                 "shasum": ""
             },
             "require": {
@@ -246,13 +253,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Filesystem\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -270,20 +280,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-18 20:23:18"
+            "time": "2016-03-27 10:20:16"
         },
         {
             "name": "symfony/finder",
-            "version": "v2.7.6",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "2ffb4e9598db3c48eb6d0ae73b04bbf09280c59d"
+                "reference": "ca24cf2cd4e3826f571e0067e535758e73807aa1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/2ffb4e9598db3c48eb6d0ae73b04bbf09280c59d",
-                "reference": "2ffb4e9598db3c48eb6d0ae73b04bbf09280c59d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ca24cf2cd4e3826f571e0067e535758e73807aa1",
+                "reference": "ca24cf2cd4e3826f571e0067e535758e73807aa1",
                 "shasum": ""
             },
             "require": {
@@ -292,13 +302,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Finder\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -316,20 +329,79 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-11 09:39:48"
+            "time": "2016-03-10 10:53:53"
         },
         {
-            "name": "symfony/process",
-            "version": "v2.7.6",
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/process.git",
-                "reference": "4a959dd4e19c2c5d7512689413921e0a74386ec7"
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "1289d16209491b584839022f29257ad859b8532d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/4a959dd4e19c2c5d7512689413921e0a74386ec7",
-                "reference": "4a959dd4e19c2c5d7512689413921e0a74386ec7",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/1289d16209491b584839022f29257ad859b8532d",
+                "reference": "1289d16209491b584839022f29257ad859b8532d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2016-01-20 09:13:37"
+        },
+        {
+            "name": "symfony/process",
+            "version": "v2.8.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "fb467471952ef5cf8497c029980e556b47545333"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/fb467471952ef5cf8497c029980e556b47545333",
+                "reference": "fb467471952ef5cf8497c029980e556b47545333",
                 "shasum": ""
             },
             "require": {
@@ -338,13 +410,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Process\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -362,20 +437,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-23 14:47:27"
+            "time": "2016-03-23 13:11:46"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v2.7.6",
+            "version": "v2.8.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "f8ab957c17e4b85a73c4df03bdf94ee597f2bd55"
+                "reference": "9e24824b2a9a16e17ab997f61d70bc03948e434e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/f8ab957c17e4b85a73c4df03bdf94ee597f2bd55",
-                "reference": "f8ab957c17e4b85a73c4df03bdf94ee597f2bd55",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/9e24824b2a9a16e17ab997f61d70bc03948e434e",
+                "reference": "9e24824b2a9a16e17ab997f61d70bc03948e434e",
                 "shasum": ""
             },
             "require": {
@@ -384,13 +459,16 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.7-dev"
+                    "dev-master": "2.8-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\Stopwatch\\": ""
-                }
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -408,7 +486,56 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2015-10-12 12:42:24"
+            "time": "2016-03-04 07:54:35"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v2.8.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "584e52cb8f788a887553ba82db6caacb1d6260bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/584e52cb8f788a887553ba82db6caacb1d6260bb",
+                "reference": "584e52cb8f788a887553ba82db6caacb1d6260bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-03-04 07:54:35"
         }
     ],
     "packages-dev": [
@@ -517,22 +644,24 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.5.0",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7"
+                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4745ded9307786b730d7a60df5cb5a6c43cf95f7",
-                "reference": "4745ded9307786b730d7a60df5cb5a6c43cf95f7",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/3c91bdf81797d725b14cb62906f9a4ce44235972",
+                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
+                "php": "^5.3|^7.0",
                 "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1"
+                "sebastian/comparator": "~1.1",
+                "sebastian/recursion-context": "~1.0"
             },
             "require-dev": {
                 "phpspec/phpspec": "~2.0"
@@ -540,7 +669,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4.x-dev"
+                    "dev-master": "1.5.x-dev"
                 }
             },
             "autoload": {
@@ -573,7 +702,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2015-08-13 10:07:40"
+            "time": "2016-02-15 07:46:21"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1009,16 +1138,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.2",
+            "version": "1.3.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44"
+                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/6324c907ce7a52478eeeaede764f48733ef5ae44",
-                "reference": "6324c907ce7a52478eeeaede764f48733ef5ae44",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
+                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
                 "shasum": ""
             },
             "require": {
@@ -1055,7 +1184,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2015-08-03 06:14:51"
+            "time": "2016-02-26 18:40:46"
         },
         {
             "name": "sebastian/exporter",
@@ -1176,16 +1305,16 @@
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba"
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/994d4a811bafe801fb06dccbee797863ba2792ba",
-                "reference": "994d4a811bafe801fb06dccbee797863ba2792ba",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
+                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
                 "shasum": ""
             },
             "require": {
@@ -1225,7 +1354,7 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-06-21 08:04:50"
+            "time": "2015-11-11 19:50:13"
         },
         {
             "name": "sebastian/version",
@@ -1261,52 +1390,6 @@
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
             "time": "2015-06-21 13:59:46"
-        },
-        {
-            "name": "symfony/yaml",
-            "version": "v2.7.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "eca9019c88fbe250164affd107bc8057771f3f4d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/eca9019c88fbe250164affd107bc8057771f3f4d",
-                "reference": "eca9019c88fbe250164affd107bc8057771f3f4d",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.9"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2015-10-11 09:39:48"
         }
     ],
     "aliases": [],

--- a/src/Symfony/Upgrade/Fixer/YamlFixer.php
+++ b/src/Symfony/Upgrade/Fixer/YamlFixer.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Symfony\Upgrade\Fixer;
+
+use Symfony\Component\Yaml;
+
+class YamlFixer extends AbstractFixer
+{
+    public function fix(\SplFileInfo $file, $content)
+    {
+        if ('yml' !== strtolower($file->getExtension())) {
+            return $content;
+        }
+
+        $wrapper = new ParserWrapper();
+
+        return (new DumperWrapper())->dumpWithComments($wrapper->parse($content), $wrapper->getMetadata());
+    }
+
+    public function getDescription()
+    {
+        return 'YAML parser becomes less permissive, you should now escape mapping values containing a colon (:) or beginning by @, `, | and > signs.';
+    }
+}
+
+class ParserWrapper extends Yaml\Parser
+{
+    private $metadata = [];
+
+    public function parse($value, $exceptionOnInvalidType = false, $objectSupport = false, $objectForMap = false)
+    {
+        $this->setParentProp('lines', explode("\n", $value));
+        while ($this->moveToNextLine()) {
+            if ($this->isCurrentLineBlank()) {
+                continue;
+            }
+            if ($this->isCurrentLineComment()) {
+                array_push($this->metadata, [
+                    'value' => $this->getParentProp('currentLine'),
+                    'nextLine' => $this->getNextLine(),
+                    'previousLine' => $this->getPreviousLine(),
+                    'lineNb' => $this->getParentProp('currentLineNb'),
+                    'realLineNb' => $this->getRealCurrentLineNb(),
+                    'indentation' => $this->getCurrentLineIndentation(),
+                ]);
+            }
+        }
+
+        return parent::parse($value, $exceptionOnInvalidType, $objectSupport, $objectForMap);
+    }
+
+    private function getNextLine()
+    {
+        $this->moveToNextLine();
+        $value = $this->getParentProp('currentLine');
+        $this->moveToPreviousLine();
+
+        return $value;
+    }
+
+    private function getPreviousLine()
+    {
+        $currentLine = $this->getParentProp('currentLineNb');
+        if ($currentLine > 0) {
+            $this->moveToPreviousLine();
+        }
+        $value = $this->getParentProp('currentLine');
+        if ($currentLine > 0) {
+            $this->moveToNextLine();
+        }
+
+        return $value;
+    }
+
+    private function getParentProp($name)
+    {
+        $prop = new \ReflectionProperty(get_parent_class($this), $name);
+        $prop->setAccessible(true);
+
+        return $prop->getValue($this);
+    }
+
+    private function setParentProp($name, $value)
+    {
+        $prop = new \ReflectionProperty(get_parent_class($this), $name);
+        $prop->setAccessible(true);
+        $prop->setValue($this, $value);
+    }
+
+    public function __call($name, $arguments)
+    {
+        $parent = (new \ReflectionClass($this))->getParentClass();
+        if ($parent->hasMethod($name)) {
+            $method = $parent->getMethod($name);
+            $method->setAccessible(true);
+            try {
+                return $method->invoke($this, $arguments);
+            } catch (\Exception $e) {
+                throw new \RuntimeException(sprintf('Method %s with args "%s" ended with exception', $name, print_r($arguments)), 0, $e);
+            }
+        }
+
+        throw new \RuntimeException(sprintf('Method %s does not exist', $name));
+    }
+
+    public function getMetadata()
+    {
+        return $this->metadata;
+    }
+}
+
+class DumperWrapper extends Yaml\Dumper
+{
+    public function dumpWithComments($input, $metadata)
+    {
+        $content = explode("\n", parent::dump($input, 4));
+        $toReturn = $content;
+        foreach ($content as $lineNb => $line) {
+            foreach ($metadata as $key => $commentData) {
+                if (0 === $commentData['lineNb']) {
+                    array_unshift($toReturn, $commentData['value']);
+                    unset($metadata[$key]);
+                    continue;
+                }
+                if ($line === $commentData['previousLine']) {
+                    array_splice($toReturn, $lineNb + 1, 0, $commentData['value']);
+                    unset($metadata[$key]);
+                    continue;
+                }
+
+                if ($line === $commentData['nextLine']) {
+                    array_splice($toReturn, $lineNb - 1, 0, $commentData['value']);
+                    unset($metadata[$key]);
+                    continue;
+                }
+            }
+        }
+
+        return implode("\n", $toReturn);
+    }
+}

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/case1-input.yml
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/case1-input.yml
@@ -1,0 +1,142 @@
+# services.yml - twigfiddle.com
+
+parameters:
+    app.oauth_user_provider.class: Fuz\AppBundle\Model\OAuthUserProvider
+    hwi_oauth.account.connector: Fuz\AppBundle\Connect\AccountConnect
+    app.form.fiddle.class: Fuz\AppBundle\Form\FiddleType
+    app.twig.debug_extension.class: Fuz\AppBundle\Twig\Extension\DebugExtension
+    app.twig.safety_extension.class: Fuz\AppBundle\Twig\Extension\SafetyExtension
+    app.twig.github_extension.class: Fuz\AppBundle\Twig\Extension\GitHubExtension
+    app.twig.hash_extension.class: Fuz\AppBundle\Twig\Extension\HashExtension
+    app.twig.pcre_extension.class: Fuz\AppBundle\Twig\Extension\PcreExtension
+    app.twig.prettify_extension.class: Fuz\AppBundle\Twig\Extension\PrettifyExtension
+    app.helper.doctrine_helper.class: Fuz\AppBundle\Helper\DoctrineHelper
+    app.subscriber.fiddle.class: Fuz\AppBundle\EventListener\FiddleSubscriber
+    app.subscriber.user.class: Fuz\AppBundle\EventListener\UserSubscriber
+    app.subscriber.user_bookmark.class: Fuz\AppBundle\EventListener\UserBookmarkSubscriber
+    app.utilities.class: Fuz\AppBundle\Util\Utilities
+    app.paginator.class: Fuz\AppBundle\Util\Paginator
+    app.captcha.class: Fuz\AppBundle\Util\Captcha
+    app.process_configuration.class: Fuz\AppBundle\Util\ProcessConfiguration
+    app.run_fiddle.class: Fuz\AppBundle\Service\RunFiddle
+    app.save_fiddle.class: Fuz\AppBundle\Service\SaveFiddle
+    app.search_fiddle.class: Fuz\AppBundle\Service\SearchFiddle
+    app.twig_extensions.class: Fuz\AppBundle\Service\TwigExtensions
+
+services:
+
+    app.oauth_user_provider:
+        class: %app.oauth_user_provider.class%
+        arguments: [@session, @doctrine.orm.entity_manager]
+
+    hwi_oauth.account.connector:
+        class: %hwi_oauth.account.connector%
+
+    app.form.fiddle:
+         class: %app.form.fiddle.class%
+         arguments: [@app.process_configuration, @app.twig_extensions]
+         tags:
+            - { name: form.type }
+
+    app.twig.debug_extension:
+         class: %app.twig.debug_extension.class%
+         arguments: []
+         tags:
+             - { name: twig.extension }
+
+    app.twig.safety_extension:
+         class: %app.twig.safety_extension.class%
+         arguments: [%kernel.root_dir%]
+         tags:
+             - { name: twig.extension }
+
+    app.twig.github_extension:
+         class: %app.twig.github_extension.class%
+         arguments: [%github_repository_root%]
+         tags:
+             - { name: twig.extension }
+
+    app.twig.hash_extension:
+         class: %app.twig.hash_extension.class%
+         arguments: []
+         tags:
+             - { name: twig.extension }
+
+    app.twig.pcre_extension:
+         class: %app.twig.pcre_extension.class%
+         arguments: []
+         tags:
+             - { name: twig.extension }
+
+    app.twig.prettify_extension:
+         class: %app.twig.prettify_extension.class%
+         arguments: []
+         tags:
+             - { name: twig.extension }
+
+    app.helper.doctrine_helper:
+         class: %app.helper.doctrine_helper.class%
+         arguments: [@doctrine.orm.entity_manager]
+
+    app.subscriber.fiddle:
+        class: %app.subscriber.fiddle.class%
+        tags:
+             - { name: doctrine.event_subscriber, connection: default }
+
+    app.subscriber.user:
+        class: %app.subscriber.user.class%
+        tags:
+             - { name: doctrine.event_subscriber, connection: default }
+
+    app.subscriber.user_bookmark:
+        class: %app.subscriber.user_bookmark.class%
+        tags:
+             - { name: doctrine.event_subscriber, connection: default }
+
+    app.utilities:
+         class: %app.utilities.class%
+         arguments: [@logger]
+         tags:
+             - { name: monolog.logger, channel: service.utilities }
+
+    app.paginator:
+         class: %app.paginator.class%
+         arguments: [@logger, @session, @security.token_storage]
+         tags:
+             - { name: monolog.logger, channel: service.paginator }
+
+    app.captcha:
+         class: %app.captcha.class%
+         arguments: [@logger, @session, @doctrine.orm.entity_manager, %web%]
+         tags:
+             - { name: monolog.logger, channel: service.captcha }
+
+    app.process_configuration:
+        class: %app.process_configuration.class%
+        arguments: [@logger, %process%, %kernel.environment%]
+        tags:
+            - { name: monolog.logger, channel: service.process_configuration }
+
+    app.run_fiddle:
+         class: %app.run_fiddle.class%
+         arguments: [@logger, @filesystem, @app.utilities, @app.process_configuration, %process%]
+         tags:
+             - { name: monolog.logger, channel: service.run_fiddle }
+
+    app.save_fiddle:
+         class: %app.save_fiddle.class%
+         arguments: [@logger, @app.utilities, @app.helper.doctrine_helper, @doctrine.orm.entity_manager, @session, @router, %web%]
+         tags:
+             - { name: monolog.logger, channel: service.save_fiddle }
+
+    app.search_fiddle:
+         class: %app.search_fiddle.class%
+         arguments: [@logger, @doctrine.orm.entity_manager, @app.paginator, %web%]
+         tags:
+             - { name: monolog.logger, channel: service.search_fiddle }
+
+    app.twig_extensions:
+        class: %app.twig_extensions.class%
+        arguments: [@logger, @app.process_configuration, %kernel.environment%]
+        tags:
+            - { name: monolog.logger, channel: service.twig_extensions }

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/case1-output.yml
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/case1-output.yml
@@ -1,0 +1,156 @@
+# services.yml - twigfiddle.com
+parameters:
+    app.oauth_user_provider.class: Fuz\AppBundle\Model\OAuthUserProvider
+    hwi_oauth.account.connector: Fuz\AppBundle\Connect\AccountConnect
+    app.form.fiddle.class: Fuz\AppBundle\Form\FiddleType
+    app.twig.debug_extension.class: Fuz\AppBundle\Twig\Extension\DebugExtension
+    app.twig.safety_extension.class: Fuz\AppBundle\Twig\Extension\SafetyExtension
+    app.twig.github_extension.class: Fuz\AppBundle\Twig\Extension\GitHubExtension
+    app.twig.hash_extension.class: Fuz\AppBundle\Twig\Extension\HashExtension
+    app.twig.pcre_extension.class: Fuz\AppBundle\Twig\Extension\PcreExtension
+    app.twig.prettify_extension.class: Fuz\AppBundle\Twig\Extension\PrettifyExtension
+    app.helper.doctrine_helper.class: Fuz\AppBundle\Helper\DoctrineHelper
+    app.subscriber.fiddle.class: Fuz\AppBundle\EventListener\FiddleSubscriber
+    app.subscriber.user.class: Fuz\AppBundle\EventListener\UserSubscriber
+    app.subscriber.user_bookmark.class: Fuz\AppBundle\EventListener\UserBookmarkSubscriber
+    app.utilities.class: Fuz\AppBundle\Util\Utilities
+    app.paginator.class: Fuz\AppBundle\Util\Paginator
+    app.captcha.class: Fuz\AppBundle\Util\Captcha
+    app.process_configuration.class: Fuz\AppBundle\Util\ProcessConfiguration
+    app.run_fiddle.class: Fuz\AppBundle\Service\RunFiddle
+    app.save_fiddle.class: Fuz\AppBundle\Service\SaveFiddle
+    app.search_fiddle.class: Fuz\AppBundle\Service\SearchFiddle
+    app.twig_extensions.class: Fuz\AppBundle\Service\TwigExtensions
+services:
+    app.oauth_user_provider:
+        class: '%app.oauth_user_provider.class%'
+        arguments:
+            - '@session'
+            - '@doctrine.orm.entity_manager'
+    hwi_oauth.account.connector:
+        class: '%hwi_oauth.account.connector%'
+    app.form.fiddle:
+        class: '%app.form.fiddle.class%'
+        arguments:
+            - '@app.process_configuration'
+            - '@app.twig_extensions'
+        tags:
+            - { name: form.type }
+    app.twig.debug_extension:
+        class: '%app.twig.debug_extension.class%'
+        arguments: {  }
+        tags:
+            - { name: twig.extension }
+    app.twig.safety_extension:
+        class: '%app.twig.safety_extension.class%'
+        arguments:
+            - '%kernel.root_dir%'
+        tags:
+            - { name: twig.extension }
+    app.twig.github_extension:
+        class: '%app.twig.github_extension.class%'
+        arguments:
+            - '%github_repository_root%'
+        tags:
+            - { name: twig.extension }
+    app.twig.hash_extension:
+        class: '%app.twig.hash_extension.class%'
+        arguments: {  }
+        tags:
+            - { name: twig.extension }
+    app.twig.pcre_extension:
+        class: '%app.twig.pcre_extension.class%'
+        arguments: {  }
+        tags:
+            - { name: twig.extension }
+    app.twig.prettify_extension:
+        class: '%app.twig.prettify_extension.class%'
+        arguments: {  }
+        tags:
+            - { name: twig.extension }
+    app.helper.doctrine_helper:
+        class: '%app.helper.doctrine_helper.class%'
+        arguments:
+            - '@doctrine.orm.entity_manager'
+    app.subscriber.fiddle:
+        class: '%app.subscriber.fiddle.class%'
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }
+    app.subscriber.user:
+        class: '%app.subscriber.user.class%'
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }
+    app.subscriber.user_bookmark:
+        class: '%app.subscriber.user_bookmark.class%'
+        tags:
+            - { name: doctrine.event_subscriber, connection: default }
+    app.utilities:
+        class: '%app.utilities.class%'
+        arguments:
+            - '@logger'
+        tags:
+            - { name: monolog.logger, channel: service.utilities }
+    app.paginator:
+        class: '%app.paginator.class%'
+        arguments:
+            - '@logger'
+            - '@session'
+            - '@security.token_storage'
+        tags:
+            - { name: monolog.logger, channel: service.paginator }
+    app.captcha:
+        class: '%app.captcha.class%'
+        arguments:
+            - '@logger'
+            - '@session'
+            - '@doctrine.orm.entity_manager'
+            - '%web%'
+        tags:
+            - { name: monolog.logger, channel: service.captcha }
+    app.process_configuration:
+        class: '%app.process_configuration.class%'
+        arguments:
+            - '@logger'
+            - '%process%'
+            - '%kernel.environment%'
+        tags:
+            - { name: monolog.logger, channel: service.process_configuration }
+    app.run_fiddle:
+        class: '%app.run_fiddle.class%'
+        arguments:
+            - '@logger'
+            - '@filesystem'
+            - '@app.utilities'
+            - '@app.process_configuration'
+            - '%process%'
+        tags:
+            - { name: monolog.logger, channel: service.run_fiddle }
+    app.save_fiddle:
+        class: '%app.save_fiddle.class%'
+        arguments:
+            - '@logger'
+            - '@app.utilities'
+            - '@app.helper.doctrine_helper'
+            - '@doctrine.orm.entity_manager'
+            - '@session'
+            - '@router'
+            - '%web%'
+        tags:
+            - { name: monolog.logger, channel: service.save_fiddle }
+    app.search_fiddle:
+        class: '%app.search_fiddle.class%'
+        arguments:
+            - '@logger'
+            - '@doctrine.orm.entity_manager'
+            - '@app.paginator'
+            - '%web%'
+        tags:
+            - { name: monolog.logger, channel: service.search_fiddle }
+    app.twig_extensions:
+        class: '%app.twig_extensions.class%'
+        arguments:
+            - '@logger'
+            - '@app.process_configuration'
+            - '%kernel.environment%'
+        tags:
+            - { name: monolog.logger, channel: service.twig_extensions }

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/comment1-input.yml
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/comment1-input.yml
@@ -1,0 +1,3 @@
+# I am test comment
+
+key: value

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/comment1-output.yml
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/comment1-output.yml
@@ -1,0 +1,2 @@
+# I am test comment
+key: value

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/comment2-input.yml
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/comment2-input.yml
@@ -1,0 +1,9 @@
+parameters:
+    app.oauth_user_provider.class: Fuz\AppBundle\Model\OAuthUserProvider
+
+services:
+    # look ma I am oauth provider
+
+    app.oauth_user_provider:
+        class: %app.oauth_user_provider.class%
+        arguments: [@session, @doctrine.orm.entity_manager]

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/comment2-output.yml
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/yaml/comment2-output.yml
@@ -1,0 +1,9 @@
+parameters:
+    app.oauth_user_provider.class: Fuz\AppBundle\Model\OAuthUserProvider
+services:
+    # look ma I am oauth provider
+    app.oauth_user_provider:
+        class: '%app.oauth_user_provider.class%'
+        arguments:
+            - '@session'
+            - '@doctrine.orm.entity_manager'

--- a/tests/Symfony/Upgrade/Test/Fixer/YamlFixerTest.php
+++ b/tests/Symfony/Upgrade/Test/Fixer/YamlFixerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Symfony\Upgrade\Test\Fixer;
+
+class YamlFixerTest extends AbstractFixerTestBase
+{
+    /**
+     * @dataProvider provideExamples
+     */
+    public function testFix($expected, $input, $file)
+    {
+        $this->makeTest($expected, $input, $file);
+    }
+
+    public function provideExamples()
+    {
+        return [
+            $this->prepareTestCase('case1-output.yml', 'case1-input.yml'),
+//            $this->prepareTestCase('comment1-output.yml', 'comment1-input.yml'),
+            $this->prepareTestCase('comment2-output.yml', 'comment2-input.yml'),
+        ];
+    }
+}


### PR DESCRIPTION
The initial idea is to save metadata like comments (maybe blank lines in future) before passing the content to parser and then add it back. 

Please, note that the POC  is dirty and hacky. I preferred to share the initial idea to be able to discuss it and to let the community help me to move in right direction if this PR deserves to live. 

What is left to be done:

- [ ] Add more fixtures and cases
- [ ] Check the ability to keep blank lines
- [ ] Currently inline comments are not supported. 