### PR TITLE
Change fabpot/php-cs-fixer to friendsofphp/php-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "fabpot/php-cs-fixer": "^1.10"
+        "friendsofphp/php-cs-fixer": "^1.10"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8"


### PR DESCRIPTION
`fabpot/php-cs-fixer` is abandoned in favor of `friendsofphp/php-cs-fixer`.

This patch avoids Composer to display warning message: 

> Package fabpot/php-cs-fixer is abandoned, you should avoid using it. Use friendsofphp/php-cs-fixer instead.