### PR TITLE
Fix class names collision

### DIFF
--- a/src/Symfony/Upgrade/Fixer/AbstractFixer.php
+++ b/src/Symfony/Upgrade/Fixer/AbstractFixer.php
@@ -44,7 +44,7 @@ abstract class AbstractFixer extends BaseAbstractFixer
         return true;
     }
 
-    protected function addUseStatement(Tokens $tokens, array $fqcn)
+    protected function addUseStatement(Tokens $tokens, array $fqcn, $alias = null)
     {
         if ($this->hasUseStatements($tokens, $fqcn)) {
             return;
@@ -61,6 +61,13 @@ abstract class AbstractFixer extends BaseAbstractFixer
             $fqcnTokens[] = new Token([T_NS_SEPARATOR, '\\']);
         }
         array_pop($fqcnTokens);
+
+        if ($alias) {
+            $fqcnTokens[] = new Token([T_WHITESPACE, ' ']);
+            $fqcnTokens[] = new Token([T_AS, 'as']);
+            $fqcnTokens[] = new Token([T_WHITESPACE, ' ']);
+            $fqcnTokens[] = new Token([T_STRING, $alias]);
+        }
 
         $tokens->insertAt(
             $importUseIndexes[0],
@@ -84,7 +91,7 @@ abstract class AbstractFixer extends BaseAbstractFixer
             return false;
         }
 
-        return null !== $tokens->findSequence([
+        return $tokens->findSequence([
             [T_CLASS],
             [T_STRING],
             [T_EXTENDS],

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/form-parent-type/case1-output.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/form-parent-type/case1-output.php
@@ -2,13 +2,13 @@
 
 namespace Umpirsky\UpgradeBundle\Form\Type;
 
-use Symfony\Component\Form\Extension\Core\Type\TextType;
+use Symfony\Component\Form\Extension\Core\Type\HiddenType;
 use Symfony\Component\Form\AbstractType;
 
 class TextType extends AbstractType
 {
     public function getParent()
     {
-        return TextType::class;
+        return HiddenType::class;
     }
 }

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/form-parent-type/case2-input.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/form-parent-type/case2-input.php
@@ -8,6 +8,6 @@ class TextType extends AbstractType
 {
     public function getParent()
     {
-        return 'hidden';
+        return 'text';
     }
 }

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/form-parent-type/case2-output.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/form-parent-type/case2-output.php
@@ -2,12 +2,13 @@
 
 namespace Umpirsky\UpgradeBundle\Form\Type;
 
+use Symfony\Component\Form\Extension\Core\Type\TextType as SymfonyTextType;
 use Symfony\Component\Form\AbstractType;
 
 class TextType extends AbstractType
 {
     public function getParent()
     {
-        return 'hidden';
+        return SymfonyTextType::class;
     }
 }

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/form-type-names/case2-input.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/form-type-names/case2-input.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Umpirsky\UpgradeBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class TextType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('content', 'text')
+        ;
+    }
+}

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/form-type-names/case2-output-php54.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/form-type-names/case2-output-php54.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Umpirsky\UpgradeBundle\Form\Type;
+
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class TextType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('content', 'Symfony\Component\Form\Extension\Core\Type\TextType')
+        ;
+    }
+}

--- a/tests/Symfony/Upgrade/Fixtures/Fixer/form-type-names/case2-output-php55+.php
+++ b/tests/Symfony/Upgrade/Fixtures/Fixer/form-type-names/case2-output-php55+.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Umpirsky\UpgradeBundle\Form\Type;
+
+use Symfony\Component\Form\Extension\Core\Type\TextType as SymfonyTextType;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+class TextType extends AbstractType
+{
+    public function buildForm(FormBuilderInterface $builder, array $options)
+    {
+        $builder
+            ->add('content', SymfonyTextType::class)
+        ;
+    }
+}

--- a/tests/Symfony/Upgrade/Test/Fixer/FormParentTypeFixerTest.php
+++ b/tests/Symfony/Upgrade/Test/Fixer/FormParentTypeFixerTest.php
@@ -16,6 +16,7 @@ class FormParentTypeFixerTest extends AbstractFixerTestBase
     {
         return [
             $this->prepareTestCase('case1-output.php', 'case1-input.php'),
+            $this->prepareTestCase('case2-output.php', 'case2-input.php'),
         ];
     }
 }

--- a/tests/Symfony/Upgrade/Test/Fixer/FormTypeNamesFixerTest.php
+++ b/tests/Symfony/Upgrade/Test/Fixer/FormTypeNamesFixerTest.php
@@ -14,10 +14,18 @@ class FormTypeNamesFixerTest extends AbstractFixerTestBase
 
     public function provideExamples()
     {
-        $outputFile = PHP_VERSION_ID > 50500 ? 'case1-output-php55+.php' : 'case1-output-php54.php';
-
         return [
-            $this->prepareTestCase($outputFile, 'case1-input.php'),
+            $this->prepareTestCase($this->getCaseOutputFileName(1), 'case1-input.php'),
+            $this->prepareTestCase($this->getCaseOutputFileName(2), 'case2-input.php'),
         ];
+    }
+
+    /**
+     * @param int $caseNumber
+     * @return string
+     */
+    private function getCaseOutputFileName($caseNumber)
+    {
+        return sprintf('case%d-output-php%s.php', $caseNumber, PHP_VERSION_ID > 50500 ? '55+' : '54');
     }
 }


### PR DESCRIPTION
Fixes class names collision when form type has the same name as symfony form type.